### PR TITLE
Cleaner check for 'rounded' & 'upppercase' 

### DIFF
--- a/Utils/Input.php
+++ b/Utils/Input.php
@@ -4,168 +4,123 @@ use LasseRafn\Initials\Initials;
 
 class Input
 {
-	public $name;
-	public $length;
-	public $size;
-	public $fontSize;
-	public $background;
-	public $color;
-	public $cacheKey;
-	public $rounded;
-	public $uppercase;
+    public $name;
+    public $length;
+    public $size;
+    public $fontSize;
+    public $background;
+    public $color;
+    public $cacheKey;
+    public $rounded;
+    public $uppercase;
 
-	private $hasQueryParameters = false;
+    private $hasQueryParameters = false;
 
-	protected static $indexes = [
-		'name',
-		'size',
-		'background',
-		'color',
-		'length',
-		'font-size',
-		'rounded',
-		'uppercase',
-	];
+    protected static $indexes = [
+        'name',
+        'size',
+        'background',
+        'color',
+        'length',
+        'font-size',
+        'rounded',
+        'uppercase',
+    ];
 
-	public function __construct()
-	{
-		$this->detectQueryParameters();
-		$this->detectUrlBasedParameters();
+    public function __construct()
+    {
+        $this->detectQueryParameters();
+        $this->detectUrlBasedParameters();
 
-		$this->name       = $_GET['name'] ?? 'John Doe';
-		$this->size       = (int) ( $_GET['size'] ?? 64 );
-		$this->background = $_GET['background'] ?? '#ddd';
-		$this->color      = $_GET['color'] ?? '#222';
-		$this->length     = (int) ( $_GET['length'] ?? 2 );
-		$this->fontSize   = (double) ( $_GET['font-size'] ?? 0.5 );
+        $this->name       = $_GET['name'] ?? 'John Doe';
+        $this->size       = (int) ( $_GET['size'] ?? 64 );
+        $this->background = $_GET['background'] ?? '#ddd';
+        $this->color      = $_GET['color'] ?? '#222';
+        $this->length     = (int) ( $_GET['length'] ?? 2 );
+        $this->fontSize   = (double) ( $_GET['font-size'] ?? 0.5 );
 
-		$this->getRounded();
-		$this->getUppercase();
-		$this->getInitials();
-		$this->fixInvalidInput();
-		$this->generateCacheKey();
-	}
+        $this->getRounded();
+        $this->getUppercase();
+        $this->getInitials();
+        $this->fixInvalidInput();
+        $this->generateCacheKey();
+    }
 
-	private function getRounded()
-	{
-		$rounded = $_GET['rounded'] ?? false;
+    private function getRounded()
+    {
+        $this->rounded = filter_var($_GET['rounded'] ?? false, FILTER_VALIDATE_BOOLEAN);
+    }
 
-		if ( is_bool( $rounded ) ) {
-			$this->rounded = $rounded;
+    private function getUppercase()
+    {
 
-			return;
-		}
+        $this->rounded = filter_var($_GET['uppercase'] ?? true, FILTER_VALIDATE_BOOLEAN);
+    }
 
-		switch ( $rounded ) {
-			case 'true':
-			case 1:
-			case '1':
-			case 'yes':
-				$this->rounded = true;
-				break;
+    private function getInitials()
+    {
+        $this->initials = ( new Initials )->length($this->length)->keepCase(!$this->uppercase)->generate($this->name);
+    }
 
-			case 'false':
-			case 0:
-			case '0':
-			case 'no':
-			default:
-				$this->rounded = false;
-				break;
-		}
-	}
+    private function generateCacheKey()
+    {
+        $this->cacheKey = md5("{$this->initials}-{$this->length}-{$this->size}-{$this->fontSize}-{$this->background}-{$this->color}-{$this->rounded}-{$this->uppercase}");
+    }
 
-	private function getUppercase()
-	{
-		$uppercase = $_GET['uppercase'] ?? true;
+    private function fixInvalidInput()
+    {
+        if ($this->length <= 0) {
+            $this->length = 1;
+        }
 
-		if ( is_bool( $uppercase ) ) {
-			$this->uppercase = $uppercase;
+        if ($this->fontSize <= 0) {
+            $this->fontSize = 0.5;
+        }
 
-			return;
-		}
+        if ($this->fontSize > 1) {
+            $this->fontSize = 1;
+        }
 
-		switch ( $uppercase ) {
-			case 'true':
-			case 1:
-			case '1':
-			case 'yes':
-			default:
-				$this->uppercase = true;
-				break;
+        if ($this->size <= 15) {
+            $this->size = 16;
+        }
 
-			case 'false':
-			case 0:
-			case '0':
-			case 'no':
-				$this->uppercase = false;
-				break;
-		}
-	}
+        if ($this->size > 256) {
+            $this->size = 256;
+        }
+    }
 
-	private function getInitials()
-	{
-		$this->initials = ( new Initials )->length( $this->length )->keepCase(!$this->uppercase)->generate( $this->name );
-	}
+    private function detectQueryParameters()
+    {
+        foreach ($_GET as $item => $value) {
+            if (in_array($item, self::$indexes, true)) {
+                $this->hasQueryParameters = true;
 
-	private function generateCacheKey()
-	{
-		$this->cacheKey = md5( "{$this->initials}-{$this->length}-{$this->size}-{$this->fontSize}-{$this->background}-{$this->color}-{$this->rounded}-{$this->uppercase}" );
-	}
+                return true;
+            }
+        }
 
-	private function fixInvalidInput()
-	{
-		if ( $this->length <= 0 ) {
-			$this->length = 1;
-		}
+        return false;
+    }
 
-		if ( $this->fontSize <= 0 ) {
-			$this->fontSize = 0.5;
-		}
+    private function detectUrlBasedParameters()
+    {
+        if ($this->hasQueryParameters) {
+            return false;
+        }
 
-		if ( $this->fontSize > 1 ) {
-			$this->fontSize = 1;
-		}
+        $requestUrl = ltrim($_SERVER['REQUEST_URI'], '/');
+        $requestUrl = ltrim($requestUrl, 'api');
+        $requestUrl = ltrim($requestUrl, '/');
 
-		if ( $this->size <= 15 ) {
-			$this->size = 16;
-		}
+        $parameters = explode('/', $requestUrl);
 
-		if ( $this->size > 256 ) {
-			$this->size = 256;
-		}
-	}
+        foreach ($parameters as $index => $value) {
+            if (! isset(self::$indexes[ $index ])) {
+                continue;
+            }
 
-	private function detectQueryParameters()
-	{
-		foreach ( $_GET as $item => $value ) {
-			if ( in_array( $item, self::$indexes, true ) ) {
-				$this->hasQueryParameters = true;
-
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	private function detectUrlBasedParameters()
-	{
-		if ( $this->hasQueryParameters ) {
-			return false;
-		}
-
-		$requestUrl = ltrim( $_SERVER['REQUEST_URI'], '/' );
-		$requestUrl = ltrim( $requestUrl, 'api' );
-		$requestUrl = ltrim( $requestUrl, '/' );
-
-		$parameters = explode( '/', $requestUrl );
-
-		foreach ( $parameters as $index => $value ) {
-			if ( ! isset( self::$indexes[ $index ] ) ) {
-				continue;
-			}
-
-			$_GET[ self::$indexes[ $index ] ] = urldecode($value);
-		}
-	}
+            $_GET[ self::$indexes[ $index ] ] = urldecode($value);
+        }
+    }
 }


### PR DESCRIPTION
Hi, man! 

This PR cleans code for `getRounded` and `getUppercase` methods to more readable ones) 
As bonus, users can use "1", "true", true, "on" and "yes" to set options to true. Default behavior don't changed btw. 

P.S. Shitty editor applied PSR formatting on save, and im too lazy to disable it 😄. 